### PR TITLE
fix: type warn

### DIFF
--- a/src/pages/home/modules/types.ts
+++ b/src/pages/home/modules/types.ts
@@ -9,7 +9,7 @@ export interface HomeState {
 }
 
 export interface MessageAction {
-  type: typeof MESSAGES_ACTIONS_SUCCESS
+  type: string
   payload: Text[]
 }
 


### PR DESCRIPTION
err msg :

```text
"message": "不能将类型“{ type: string; payload: Text[]; }”分配给类型“MessageAction”。\n  属性“type”的类型不兼容。\n    不能将类型“string”分配给类型“\"MESSAGES_ACTIONS_SUCCESS\"”。",
```